### PR TITLE
support for not cancelling notifs from specific channel

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -218,10 +218,12 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
      * Cancels all scheduled local notifications, and removes all entries from the notification
      * centre.
      *
+     * @channelIdToSkipCancelling - use for excluding channel from getting canceled.
+     *
      */
-    public void cancelAllLocalNotifications() {
+    public void cancelAllLocalNotifications(String channelIdToSkipCancelling) {
         mRNPushNotificationHelper.cancelAllScheduledNotifications();
-        mRNPushNotificationHelper.clearNotifications();
+        mRNPushNotificationHelper.clearNotifications(channelIdToSkipCancelling);
     }
 
     @ReactMethod
@@ -247,7 +249,7 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
      *
      */
     public void removeAllDeliveredNotifications() {
-      mRNPushNotificationHelper.clearNotifications();
+      mRNPushNotificationHelper.clearNotifications(null);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -680,11 +680,21 @@ public class RNPushNotificationHelper {
         }
     }
 
-    public void clearNotifications() {
+    public void clearNotifications(String channelIdToSkipCancelling) {
         Log.i(LOG_TAG, "Clearing alerts from the notification centre");
 
         NotificationManager notificationManager = notificationManager();
-        notificationManager.cancelAll();
+
+        if (channelIdToSkipCancelling == null || channelIdToSkipCancelling.trim().isEmpty()) {
+            notificationManager.cancelAll();
+        } else {
+            for (StatusBarNotification notif: notificationManager.getActiveNotifications()
+            ) {
+                if (!notif.getNotification().getChannelId().equals(channelIdToSkipCancelling)) {
+                    notificationManager.cancel(notif.getId());
+                }
+            }
+        }
     }
 
     public void clearNotification(String tag, int notificationID) {

--- a/component/index.android.js
+++ b/component/index.android.js
@@ -44,8 +44,8 @@ NotificationsComponent.prototype.clearLocalNotification = function(details, tag)
 	RNPushNotification.clearLocalNotification(details, tag);
 };
 
-NotificationsComponent.prototype.cancelAllLocalNotifications = function() {
-	RNPushNotification.cancelAllLocalNotifications();
+NotificationsComponent.prototype.cancelAllLocalNotifications = function(channelIdToSkipCancelling) {
+	RNPushNotification.cancelAllLocalNotifications(channelIdToSkipCancelling);
 };
 
 NotificationsComponent.prototype.presentLocalNotification = function(details) {


### PR DESCRIPTION
this is related to https://github.com/TeamAround/Around/pull/6346

on ios we can safely call `cancelAllLocalNotifications` but on android we do have ongoing in-room notif and that would get cancelled as well ...

so, the solution is to add support herer to be able to exclude cancelling of notifs from sepcific notification channel